### PR TITLE
Remove original author and last updated

### DIFF
--- a/posit_workbench_and_global_options.md
+++ b/posit_workbench_and_global_options.md
@@ -1,9 +1,5 @@
 # Recommendations on Global Options in Posit Workbench
 
-Original author(s): Terry McLaughlin
-
-Last updated: January 2023
-
 ## Background
 
 [Posit Team](https://posit.co/products/enterprise/team/) enterprise applications have been deployed for [Public Health Scotland (PHS)](https://publichealthscotland.scot/) on the [Microsoft Azure](https://azure.microsoft.com/en-gb/) cloud computing platform. [Posit Workbench](https://posit.co/products/enterprise/workbench/) makes use of the managed [Azure Kubernetes Service (AKS)](https://azure.microsoft.com/en-us/products/kubernetes-service/#overview) to provide a scalable, performant and highly-available analytical environment.

--- a/posit_workbench_and_kubernetes.md
+++ b/posit_workbench_and_kubernetes.md
@@ -1,9 +1,5 @@
 # Posit Workbench and Kubernetes
 
-Original author(s): Terry McLaughlin
-
-Last updated: December 2022
-
 ## Background
 
 [Posit Team](https://posit.co/products/enterprise/team/) enterprise applications have been deployed for [Public Health Scotland (PHS)](https://publichealthscotland.scot/) on the [Microsoft Azure](https://azure.microsoft.com/en-gb/) cloud computing platform. [Posit Workbench](https://posit.co/products/enterprise/workbench/) makes use of the managed [Azure Kubernetes Service (AKS)](https://azure.microsoft.com/en-us/products/kubernetes-service/#overview) to provide a scalable, performant and highly-available analytical environment.

--- a/posit_workbench_best_practice_with_r.md
+++ b/posit_workbench_best_practice_with_r.md
@@ -1,9 +1,5 @@
 # Best Practice with R in Posit Workbench
 
-Original author(s): Andrew Patterson (Jumping Rivers), Terry McLaughlin
-
-Last updated: January 2023
-
 ## Background
 
 [Posit Team](https://posit.co/products/enterprise/team/) enterprise applications have been deployed for [Public Health Scotland (PHS)](https://publichealthscotland.scot/) on the [Microsoft Azure](https://azure.microsoft.com/en-gb/) cloud computing platform. The platform has been designed and implemented as a high-performance, high-availability analytical environment to support the work of Public Health Scotland. However, despite the computing power available, we need to be mindful at all times that this is a shared resource with finite capacity, and as such, we each have individual responsibility to ensure our code is as optimised and efficient as possible, and that we use the Posit Team applications correctly and appropriately, to ensure what we all benefit from this resource equitably. Using inefficient code can cause your analysis to take longer or even cause the session to become unresponsive.


### PR DESCRIPTION
Some Posit documentation still had the original author and the date the document was last updated at the top of the page.  This pull request removes this from each of the documents.